### PR TITLE
Issue #55: Stop Settings Page for Observers

### DIFF
--- a/src/pdfoundry/Setup.ts
+++ b/src/pdfoundry/Setup.ts
@@ -272,7 +272,12 @@ export default class Setup {
             if (isEntityPDF(journalEntry)) {
                 target.find('h4').on('click', (event) => {
                     event.stopImmediatePropagation();
-                    Setup.onClickPDFName(journalEntry);
+                    if (journalEntry.owner) {
+                        Setup.onClickPDFName(journalEntry);
+                    }
+                    else {
+                        Setup.onClickPDFThumbnail(journalEntry);
+                    }
                 });
 
                 const pdfData = getPDFData(journalEntry);


### PR DESCRIPTION
Changed click on journal entry to: If owner show properies else show PDF immediately. It is a very simple "fix".