### PR TITLE
Legibility for form fillable PDFs

### DIFF
--- a/pdfjs/web/viewer.css
+++ b/pdfjs/web/viewer.css
@@ -119,7 +119,7 @@
   background-color: rgba(0, 54, 255, 0.13);
   border: 1px solid transparent;
   box-sizing: border-box;
-  font-size: 9px;
+  font-size: 19px;
   height: 100%;
   margin: 0;
   padding: 0 3px;


### PR DESCRIPTION
Debugging for my sister I found that their attempt to use character sheets with form fillable PDFs was failing due to needing to zoom so heavily on the input fields of PDFs. This change allows at a glance visibility of input boxes at PDF sizes below 100%.