### PR TITLE
Use document title name for window

### DIFF
--- a/src/pdfoundry/viewer/BaseViewer.ts
+++ b/src/pdfoundry/viewer/BaseViewer.ts
@@ -137,7 +137,7 @@ export default abstract class BaseViewer extends Application {
      * @override
      */
     public get title(): string {
-        return game.i18n.localize('PDFOUNDRY.VIEWER.ViewPDF');
+        return this.document?.name ?? game.i18n.localize('PDFOUNDRY.VIEWER.ViewPDF');
     }
 
     /**


### PR DESCRIPTION
The title of the PDF Viewer should be the name of the document it is rendering, instead of a static "View PDF"

Fixes: https://github.com/Djphoenix719/PDFoundry/issues/122