### PR TITLE
Adds a click listener for bringing window to top

### DIFF
--- a/src/pdfoundry/viewer/BaseViewer.ts
+++ b/src/pdfoundry/viewer/BaseViewer.ts
@@ -222,6 +222,7 @@ export default abstract class BaseViewer extends Application {
 
             const theme = Api.activeTheme;
             const frameDocument = $(this._frame.contentDocument as Document);
+            frameDocument.on('click',() => this.bringToTop());
             const head = frameDocument.find('head');
             head.append($(`<link href="${getAbsoluteURL(theme.filePath)}" rel="stylesheet" type="text/css" media="all">`));
 


### PR DESCRIPTION
When having multiple PDF windows open, click on others does not bring them to top. I am not sure if this affects others but for me this has been some pain for a long while :D