### PR TITLE
Add vultrobjects.com to whitelist

### DIFF
--- a/src/pdfoundry/common/Whitelist.ts
+++ b/src/pdfoundry/common/Whitelist.ts
@@ -17,4 +17,4 @@
  * The domain white list includes domains that are allowed other than 'localhost' or
  *  the equivalent domain the user is running the server on.
  */
-export const DOMAIN_WHITELIST = ['amazonaws.com', 'digitaloceanspaces.com', 'assets.forge-vtt.com', 'wasabisys.com', 'backblazeb2.com'];
+export const DOMAIN_WHITELIST = ['amazonaws.com', 'digitaloceanspaces.com', 'assets.forge-vtt.com', 'wasabisys.com', 'backblazeb2.com', 'vultrobjects.com'];


### PR DESCRIPTION
Here is the URL for the takedown instructions for Vultr:
https://www.vultr.com/legal/copyright/